### PR TITLE
Rewrite print statements as print functions

### DIFF
--- a/addfriendstolist.py
+++ b/addfriendstolist.py
@@ -28,10 +28,10 @@ with open(file, mode='r') as f:
     friends = [line.rstrip('\n') for line in f]
 
 lists = api.lists_all()
-print "List of the lists \n"
+print('List of the lists')
 for list in lists:
-    print "list: ", list.slug, list.id
+    print('list:', list.slug, list.id)
 
 for friend in friends:
     api.add_list_member(owner_id=bot_id, slug=slug, user_id=int(friend))
-    print "The user {} was added to list {}.".format(friend,slug)
+    print('The user {0} was added to list {1}.'.format(friend, slug)

--- a/doctoctocbot.py
+++ b/doctoctocbot.py
@@ -30,7 +30,7 @@ tweetLanguage = config.get("settings", "tweet_language")
 
 # Number retweets per time
 num = int(config.get("settings", "number_of_rt"))
-print "number of rt: ", num
+print('Number of retweets:', num)
 
 # whitelisted users and words
 # eg: ["medecinelibre", "freemedsoft"]
@@ -38,7 +38,7 @@ print "number of rt: ", num
 with open(docsfile, 'r') as f:
     userIdWhiteList = [line.rstrip('\n') for line in f]
 
-print "Number of users in white list:", len(userIdWhiteList)
+print('Number of users in white list:', len(userIdWhiteList))
 
 
 # build savepoint path + file
@@ -58,7 +58,7 @@ try:
         savepoint = file.read()
 except IOError:
     savepoint = ""
-    print("No savepoint found. Bot is now searching for results")
+    print('No savepoint found. Bot is now searching for results')
 
 # search query
 timelineIterator = tweepy.Cursor(api.search, q=hashtag, since_id=savepoint, lang=tweetLanguage).items(num)
@@ -74,21 +74,21 @@ for tweet in timelineIterator:
     screenname = user.screen_name
     userid = user.id
     useridstring = str(userid)
-    print "userid: ", userid
-    print "useridstring: ", useridstring
-    print "screen name: ", screenname
-    print "useridstring in whitelist? ", (useridstring in userIdWhiteList)
+    print('userid:', userid)
+    print('useridstring:', useridstring)
+    print('screen name:', screenname)
+    print('Is user in whitelist:', (useridstring in userIdWhiteList))
     if hasattr(tweet, 'retweeted_status'):
         isRetweet = True
-        print "retweet: ", isRetweet
-    print "text: ", tweet.text.encode('utf-8')
-    print "(useridstring in userIdWhiteList):", (useridstring in userIdWhiteList)
-    print "not isRetweet:", not isRetweet
+        print('Is retweet:', isRetweet)
+    print('text:', tweet.text.encode('utf-8'))
+    print('Is user in whitelist:', (useridstring in userIdWhiteList))
+    print('Is retweet:', isRetweet)
     if ((useridstring in userIdWhiteList) and (not isRetweet)):
         oklist.append(tweet)
-        print "User in whitelist AND status not a RT: OK for RT \n\n"
+        print('Tweet will be retweeted')
     else:
-        print "not ok for RT \n\n"
+        print('Tweet will not be retweeted')
 
 
 try:
@@ -112,11 +112,10 @@ err_counter = 0
 # iterate the timeline and retweet
 for status in oklist:
     try:
-        print("(%(date)s) %(name)s: %(message)s\n" % \
-              {"date": status.created_at,
-               "name": status.author.screen_name.encode('utf-8'),
-               "message": status.text.encode('utf-8'),
-               "retweeted": isRetweet})
+        print('{0} {1} {2}'.format(
+            status.created_at,
+            status.author.screen_name.encode('utf-8'),
+            status.text.encode('utf-8')))
 
         # api.retweet(status.id)
         tw_counter += 1
@@ -126,7 +125,7 @@ for status in oklist:
         # print e
         continue
 
-print("Finished. %d Tweets retweeted, %d errors occured." % (tw_counter, err_counter))
+print('Finished.', tw_counter, 'tweets retweeted.', err_counter, 'errors occured.')
 
 # write last retweeted tweet id to file
 with open(last_id_file, "w") as file:

--- a/getbio.py
+++ b/getbio.py
@@ -6,12 +6,12 @@ import os, configparser, tweepy, inspect, codecs, io
 path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
 # friends file
-friendsfile = os.path.join(path, "friends")                                            
-print "friends file:", friendsfile
+friendsfile = os.path.join(path, "friends")
+print('friends file:', friendsfile)
 
 # bio file
-biofile = os.path.join(path, "bio")                                            
-print "bio file:", biofile 
+biofile = os.path.join(path, "bio")
+print('bio file:', biofile)
 
 # read config
 config = configparser.SafeConfigParser()
@@ -27,7 +27,7 @@ tweetLanguage = config.get("settings", "tweet_language")
 with open(friendsfile, 'r') as f:
     friends = [line.rstrip('\n') for line in f]
 
-print "Number of friends:", len(friends)
+print('Number of friends:', len(friends))
 
 # create bot
 auth = tweepy.OAuthHandler(config.get("twitter", "consumer_key"), config.get("twitter", "consumer_secret"))
@@ -44,6 +44,6 @@ for chunk in friendschunks:
     for user in users:
         bio+=(user.description + "\n")
 
-print bio
+print(bio)
 with io.open(biofile, encoding='utf-8', mode='wt') as f:
     f.write(bio)

--- a/occurence.py
+++ b/occurence.py
@@ -15,4 +15,4 @@ for word in match_pattern:
 frequency_list = frequency.keys()
 
 for words in frequency_list:
-    print words, frequency[words]
+    print(words, frequency[words])


### PR DESCRIPTION
Fix issue #5, python scripts where using the old python syntax for printing causing errors if run by Python 3.6.2.